### PR TITLE
Remove <%= @mod %>.worker

### DIFF
--- a/elixir/1/index.md
+++ b/elixir/1/index.md
@@ -444,7 +444,7 @@ defmodule Portal do
 
     children = [
       # Define workers and child supervisors to be supervised
-      # worker(<%= @mod %>.Worker, [arg1, arg2, arg3])
+      # worker(Portal.Worker, [arg1, arg2, arg3])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html


### PR DESCRIPTION
@josevalim I don't think this is a bug in EEX or Mix because I just tried on 0.14.2 so it must be a copy paste error? Or older version of elixir/mix. 
