### PR TITLE
Update Go article with API key for OpenWeatherMap

### DIFF
--- a/go/1/index.md
+++ b/go/1/index.md
@@ -172,9 +172,11 @@ It can serve requests directly from the live internet—no intermediary required
 We can do something more interesting than just say hello.
 Let's take a city as input, call out to a weather API, and forward a response with the temperature.
 The [OpenWeatherMap](http://openweathermap.org/)
- provides a [simple and free API](http://openweathermap.org/api)
- for [current forecast info](http://openweathermap.org/current),
- which we can [query by city](http://api.openweathermap.org/data/2.5/weather?q=Tokyo).
+provides a [simple and free API](http://openweathermap.org/api)
+for [current forecast info](http://openweathermap.org/current).
+[Register](http://home.openweathermap.org/users/sign_up) for a free
+account to get an API key. OpenWeatherMap's API can be [queried by
+city](http://api.openweathermap.org/data/2.5/weather?APPID=YOUR_API_KEY&q=Tokyo).
 It returns responses like this (partially redacted):
 
 ```json
@@ -233,7 +235,7 @@ Let's write a function to do that.
 
 ```go
 func query(city string) (weatherData, error) {
-    resp, err := http.Get("http://api.openweathermap.org/data/2.5/weather?q=" + city)
+    resp, err := http.Get("http://api.openweathermap.org/data/2.5/weather?APPID=YOUR_API_KEY&q=" + city)
     if err != nil {
         return weatherData{}, err
     }
@@ -337,7 +339,7 @@ func hello(w http.ResponseWriter, r *http.Request) {
 }
 
 func query(city string) (weatherData, error) {
-    resp, err := http.Get("http://api.openweathermap.org/data/2.5/weather?q=" + city)
+    resp, err := http.Get("http://api.openweathermap.org/data/2.5/weather?APPID=YOUR_API_KEY&q=" + city)
     if err != nil {
         return weatherData{}, err
     }
@@ -397,7 +399,7 @@ And we'll add a simple line of logging, so we can see what's happening.
 type openWeatherMap struct{}
 
 func (w openWeatherMap) temperature(city string) (float64, error) {
-    resp, err := http.Get("http://api.openweathermap.org/data/2.5/weather?q=" + city)
+    resp, err := http.Get("http://api.openweathermap.org/data/2.5/weather?APPID=YOUR_API_KEY&q=" + city)
     if err != nil {
         return 0, err
     }


### PR DESCRIPTION
This fixes the Go article by @peterbourgon to have info and code about
using the OpenWeatherMap API key that is now required. I noticed this by
going through the article, and the adjustments are fairly minor.

The reason for this change is that starting on October 9, 2015,
OpenWeatherMap started to require an API key (a.k.a. APPID) to make
requests. See http://openweathermap.org/faq for more info on this
requirement and http://openweathermap.org/appid on using the APPID.

The new code in the article requires the person going through it to
insert their API key where it says "YOUR_API_KEY". The requests to
OpenWeatherMap will then work as expected.

-----

@peterbourgon I tried to not change the text too much, but since it required some info about registering for an API key, I had to add some text. Since this is your writing, feel free to adjust and tweak it. Let me know if you would prefer a different approach for someone inputting their API key into the URL string.

Here is the PR to fix the complete code example: https://github.com/peterbourgon/how-i-start-go/pull/4