### PR TITLE
Fix using depricated functon String.rjust

### DIFF
--- a/elixir/1/index.md
+++ b/elixir/1/index.md
@@ -377,8 +377,8 @@ defimpl Inspect, for: Portal do
 
     """
     #Portal<
-      #{String.rjust(left_door, max)} <=> #{right_door}
-      #{String.rjust(left_data, max)} <=> #{right_data}
+      #{String.pad_leading(left_door, max)} <=> #{right_door}
+      #{String.pad_leading(left_data, max)} <=> #{right_data}
     >
     """
   end


### PR DESCRIPTION
String.rjust is deprecated. Using String.pad_leading is recommended.